### PR TITLE
Fix bug in FindClusters usage

### DIFF
--- a/seurat-find-clusters.R
+++ b/seurat-find-clusters.R
@@ -56,7 +56,7 @@ option_list = list(
   make_option(
     c("-r", "--resolution"),
     action = "store",
-    default = NULL,
+    default = 0.8,
     type = 'double',
     help = "Value of the resolution parameter, use a value above (below) 1.0 if you want to obtain a larger (smaller) number of communities."
   ),


### PR DESCRIPTION
This PR fixes the Seurat FindClusters bug we found in the hackathon, caused by an inappropriate default for the resolution parameter. 