### PR TITLE
Try adding libgfortran as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse libpng r-cairo r-workflowscriptscommon r-seurat;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION libgfortran r-base r-optparse libpng r-cairo r-workflowscriptscommon r-seurat;
     fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION libgfortran r-base r-optparse libpng r-cairo r-workflowscriptscommon r-seurat;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base=3.4.1 r-optparse libpng r-cairo r-workflowscriptscommon r-seurat=2.3.1;
     fi
 
 install:


### PR DESCRIPTION
https://github.com/ebi-gene-expression-group/r-seurat-scripts/pull/6 suddenly had issues with lack of libgfortran libraries. I tried adding libgfortran as dependency, but turned out it was lack of R version pinning, as with the testing on the Bioconda recipes repo. Pinning the dependencies fixed things.