### PR TITLE
Added introspective text to steps where reporting makes sense

### DIFF
--- a/seurat-create-seurat-object.R
+++ b/seurat-create-seurat-object.R
@@ -47,6 +47,16 @@ sc_matrix <- readRDS(opt$input_object_file)
 
 seurat_object <- CreateSeuratObject(sc_matrix)
 
+# Print an object summary
+
+cat(c(
+  '# Object summary', 
+  capture.output(print(seurat_object)), 
+  '\n# Metadata sample', 
+  capture.output(head(seurat_object@meta.data))
+), 
+sep = '\n')
+
 # Output to a serialized R object
 
 saveRDS(seurat_object, file = opt$output_object_file)

--- a/seurat-filter-cells.R
+++ b/seurat-filter-cells.R
@@ -88,6 +88,7 @@ if (! is.null(cells_use)){
   }
   
   check_cells(cells_use, seurat_object)
+  print(paste('Filtering to', length(cells_use), 'specified cells'))
 }
 
 # Now we're hapy with the arguments, load Seurat and do the work
@@ -95,6 +96,20 @@ if (! is.null(cells_use)){
 suppressPackageStartupMessages(require(Seurat))
 
 filtered_seurat_object <- FilterCells(seurat_object, subset.names = subset_names, low.thresholds = lt, high.thresholds = ht, cells.use = cells_use)
+
+# Print a summary of the affects of filtering
+
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-5,-6), , drop = FALSE]
+
+cat(c(
+  '# Before filtering:', 
+  capture.output(print(seurat_object)), 
+  '\n# After filtering:', 
+  capture.output(print(filtered_seurat_object)),
+  '\n# Parameter values:\n',
+  capture.output(print(opt_table))
+), 
+sep = '\n')
 
 # Output to a serialized R object
 

--- a/seurat-filter-cells.R
+++ b/seurat-filter-cells.R
@@ -99,7 +99,12 @@ filtered_seurat_object <- FilterCells(seurat_object, subset.names = subset_names
 
 # Print a summary of the affects of filtering
 
-opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-5,-6), , drop = FALSE]
+# Some parameters aren't interesting for reporting purposes (e.g. file
+# locations), so hide from the summary
+
+nonreport_params <- c('input_object_file', 'output_object_file', 'help')
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)
+opt_table <- opt_table[! rownames(opt_table) %in% nonreport_params, , drop = FALSE]
 
 cat(c(
   '# Before filtering:', 

--- a/seurat-find-clusters.R
+++ b/seurat-find-clusters.R
@@ -125,9 +125,18 @@ clustered_object <- FindClusters(seurat_object, genes.use = genes_use, reduction
 
 # Summarise the clustering
 
-opt_table <- data.frame(parameter=names(opt), value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-7,-8,-9,-10),]
+# Some parameters aren't interesting for reporting purposes (e.g. file
+# locations), so hide from the summary
 
-cat(paste(ncol(clustered_object@data), 'cells fall into ', length(unique(clustered_object@ident)), 'final clusters. Membership numbers:'), capture.output(table(clustered_object@ident)), '\nParameter values:\n', capture.output(print(opt_table)), sep = '\n')
+nonreport_params <- c('input_object_file', 'output_object_file', 'help', 'output_text_file', 'tmp_file_location')
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)
+opt_table <- opt_table[! rownames(opt_table) %in% nonreport_params, , drop = FALSE]
+
+cluster_table <- as.data.frame(table(clustered_object@ident))
+colnames(cluster_table) <- c('Cluster', 'No. cells')
+rownames(cluster_table) <- cluster_table$Cluster
+
+cat(paste(ncol(clustered_object@data), 'cells fall into ', length(unique(clustered_object@ident)), 'final clusters. Membership numbers:\n'), capture.output(cluster_table[,2, drop = FALSE]), '\nParameter values:\n', capture.output(print(opt_table)), sep = '\n')
 
 # Output to a serialized R object
 

--- a/seurat-find-clusters.R
+++ b/seurat-find-clusters.R
@@ -70,7 +70,7 @@ option_list = list(
   make_option(
     c("-m", "--tmp-file-location"),
     action = "store",
-    default = 1,
+    default = NULL,
     type = 'character',
     help = "Directory where intermediate files will be written. Specify the ABSOLUTE path."
   ),
@@ -122,6 +122,12 @@ suppressPackageStartupMessages(require(Seurat))
 seurat_object <- readRDS(opt$input_object_file)
 
 clustered_object <- FindClusters(seurat_object, genes.use = genes_use, reduction.type = opt$reduction_type, dims.use = dims_use, k.param = opt$k_param, prune.SNN = opt$prune_snn, print.output = FALSE, save.SNN = FALSE, resolution = opt$resolution, temp.file.location = opt$temp_file_location)
+
+# Summarise the clustering
+
+opt_table <- data.frame(parameter=names(opt), value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-7,-8,-9,-10),]
+
+cat(paste(ncol(clustered_object@data), 'cells fall into ', length(unique(clustered_object@ident)), 'final clusters. Membership numbers:'), capture.output(table(clustered_object@ident)), '\nParameter values:\n', capture.output(print(opt_table)), sep = '\n')
 
 # Output to a serialized R object
 

--- a/seurat-find-markers.R
+++ b/seurat-find-markers.R
@@ -137,7 +137,12 @@ results_matrix <- FindAllMarkers(
 
 # Summarise output
 
-opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-11, -12),, drop=FALSE]
+# Some parameters aren't interesting for reporting purposes (e.g. file
+# locations), so hide from the summary
+
+nonreport_params <- c('input_object_file', 'output_object_file', 'help', 'output_text_file')
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)
+opt_table <- opt_table[! rownames(opt_table) %in% nonreport_params, , drop = FALSE]
 
 markers_by_cluster <- merge(
   data.frame(as.matrix(table(seurat_object@ident))),

--- a/seurat-find-markers.R
+++ b/seurat-find-markers.R
@@ -135,6 +135,25 @@ results_matrix <- FindAllMarkers(
   max.cells.per.ident = opt$max_cells_per_ident
 )
 
+# Summarise output
+
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-11, -12),, drop=FALSE]
+
+markers_by_cluster <- merge(
+  data.frame(as.matrix(table(seurat_object@ident))),
+  data.frame(as.matrix(table(results_matrix$cluster))),
+  by = 'row.names'
+)
+rownames(markers_by_cluster) <- markers_by_cluster[,1]
+colnames(markers_by_cluster) <- c('Cluster', 'No. cells', 'No. markers')
+
+cat(c(
+  "Summary of markers found:\n",
+  capture.output(markers_by_cluster[,-1]),
+  '\nParameter values:', 
+  capture.output(print(opt_table))
+  ), sep = '\n')
+
 # Output variable genes to a simple text file
 
 write.csv(results_matrix, file = opt$output_text_file, row.names = TRUE)

--- a/seurat-find-variable-genes.R
+++ b/seurat-find-variable-genes.R
@@ -78,8 +78,6 @@ option_list = list(
 
 opt <- wsc_parse_args(option_list, mandatory = c('input_object_file', 'output_object_file', 'output_text_file'))
 
-saveRDS(opt, file="~/Desktop/foo.rds")
-
 # Check parameter values
 
 if ( ! file.exists(opt$input_object_file)){

--- a/seurat-find-variable-genes.R
+++ b/seurat-find-variable-genes.R
@@ -99,7 +99,12 @@ saveRDS(variable_genes_seurat_object, file = opt$output_object_file)
 
 # Output variable gene numbers
 
-opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-8,-9,-10),, drop=FALSE]
+# Some parameters aren't interesting for reporting purposes (e.g. file
+# locations), so hide from the summary
+
+nonreport_params <- c('input_object_file', 'output_object_file', 'help', 'output_text_file')
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)
+opt_table <- opt_table[! rownames(opt_table) %in% nonreport_params, , drop = FALSE]
 
 cat(c(
     paste(length(variable_genes_seurat_object@var.genes), 'variable genes detected out of total', nrow(seurat_object@data))),

--- a/seurat-find-variable-genes.R
+++ b/seurat-find-variable-genes.R
@@ -78,6 +78,8 @@ option_list = list(
 
 opt <- wsc_parse_args(option_list, mandatory = c('input_object_file', 'output_object_file', 'output_text_file'))
 
+saveRDS(opt, file="~/Desktop/foo.rds")
+
 # Check parameter values
 
 if ( ! file.exists(opt$input_object_file)){
@@ -96,6 +98,16 @@ variable_genes_seurat_object <- FindVariableGenes(seurat_object, mean.function =
 # Output to a serialized R object
 
 saveRDS(variable_genes_seurat_object, file = opt$output_object_file)
+
+# Output variable gene numbers
+
+opt_table <- data.frame(value=unlist(opt), stringsAsFactors = FALSE)[c(-1,-8,-9,-10),, drop=FALSE]
+
+cat(c(
+    paste(length(variable_genes_seurat_object@var.genes), 'variable genes detected out of total', nrow(seurat_object@data))),
+    '\nParameter values:', 
+    capture.output(print(opt_table)
+), sep = '\n')          
 
 # Output variable genes to a simple text file
 

--- a/seurat-read-10x.R
+++ b/seurat-read-10x.R
@@ -43,6 +43,10 @@ suppressPackageStartupMessages(require(Seurat))
 
 sc_matrix <- Read10X(data.dir = opt$data_dir)
 
+# Use the default show method to print feedback
+
+printSpMatrix2(sc_matrix, note.dropping.colnames = FALSE, maxp = 500)
+
 # Output to a serialized R object
 
 saveRDS(sc_matrix, file = opt$output_object_file)


### PR DESCRIPTION
This PR adds introspective text to STDOUT for Seurat steps where it seemed to make sense to do so. There were steps like normalisation etc where there wasn't really anything to report.

Where I have reported summaries I've also output parameters (where appropriate) so that different runs with different results can be compared more easily.

There is also a minor bug fix here concerning a default parameter value in seurat-find-clusters.R.