### PR TITLE
add check.names=FALSE when parsing metadata

### DIFF
--- a/seurat-read.R
+++ b/seurat-read.R
@@ -122,7 +122,9 @@ if (! is.na(opt$data_dir)){
 
 cell_metadata<-NULL
 if ( ! is.null(opt$metadata) ) {
-  cell_metadata<-read.table(opt$metadata,header = TRUE, sep="\t", row.names = 1)
+  cell_metadata<-read.table(opt$metadata,header = TRUE, sep="\t",
+                            row.names = 1, check.names = FALSE, 
+                            stringsAsFactors = FALSE)
   # vvv below is to avoid https://github.com/satijalab/seurat/issues/2310
   for ( name in colnames(cell_metadata)) {
     cell_metadata[[name]]<-gsub("^$", "N/A", trimws(cell_metadata[[name]]))

--- a/seurat-read.R
+++ b/seurat-read.R
@@ -123,7 +123,7 @@ if (! is.na(opt$data_dir)){
 cell_metadata<-NULL
 if ( ! is.null(opt$metadata) ) {
   cell_metadata<-read.table(opt$metadata, 
-			    header = TRUE, sep="\t",
+                            header = TRUE, sep="\t",
                             row.names = 1, check.names = FALSE, 
                             stringsAsFactors = FALSE)
   # vvv below is to avoid https://github.com/satijalab/seurat/issues/2310

--- a/seurat-read.R
+++ b/seurat-read.R
@@ -122,7 +122,8 @@ if (! is.na(opt$data_dir)){
 
 cell_metadata<-NULL
 if ( ! is.null(opt$metadata) ) {
-  cell_metadata<-read.table(opt$metadata,header = TRUE, sep="\t",
+  cell_metadata<-read.table(opt$metadata, 
+			    header = TRUE, sep="\t",
                             row.names = 1, check.names = FALSE, 
                             stringsAsFactors = FALSE)
   # vvv below is to avoid https://github.com/satijalab/seurat/issues/2310


### PR DESCRIPTION
This PR helps to avoid problems with parsing metadata files. In some cases, spaces or other illegal characters might be present in metadata field names. By default, R puts dots instead of those characters, which complicates things for downstream analyses. To avoid this, we disable this feature.
NB: this implies that the `$` operator is now deprecated in favour of subsetting via `[ ]`.

Add `check.names=FALSE` to text files parsing