### PR TITLE
remove mandatory parameter requirement

### DIFF
--- a/seurat-scale-data.R
+++ b/seurat-scale-data.R
@@ -111,7 +111,7 @@ option_list = list(
   )
 )
 
-opt <- wsc_parse_args(option_list, mandatory = c('input_object_file', 'output_object_file', 'vars_to_regress'))
+opt <- wsc_parse_args(option_list, mandatory = c('input_object_file', 'output_object_file'))
 
 # Check parameter values
 


### PR DESCRIPTION
`seurat-scale-data.R` had `--vars-to-regress` specified as a compulsory parameter. However, in the package vignette, this parameter is omitted, so we can remove the requirement. 